### PR TITLE
Subcommand `api`: Supports `--stdin` 

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,8 +1,19 @@
-use anyhow::Result;
+use anyhow::{anyhow, bail, Context, Result};
+use azure_core::credentials::TokenCredential;
+use clap::ArgMatches;
 use metadata_index::Index;
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
-use crate::arg::CliInput;
+use std::str::FromStr;
+
+use crate::{
+    api::{
+        cli_expander::{CLIExpander, Shell},
+        invoke::OperationInvocation,
+    },
+    arg::CliInput,
+    client::Client,
+};
 pub mod cli_expander;
 pub mod invoke;
 pub mod metadata_command;
@@ -10,21 +21,96 @@ pub mod metadata_index;
 
 #[derive(Debug, Clone)]
 pub struct ApiManager {
+    pub root_path: PathBuf,
     pub index: Index,
     #[allow(dead_code)]
     commands_path: PathBuf,
 }
 
 impl ApiManager {
-    pub fn locate_command_file(&self, input: &CliInput) -> Result<String> {
-        self.index.locate_command_file(input)
+    pub async fn run<F>(
+        &self,
+        subcommands: &Vec<String>,
+        args: &CliInput,
+        matches: &ArgMatches,
+        cred_func: F,
+    ) -> Result<String>
+    where
+        F: FnOnce() -> Result<Arc<dyn TokenCredential>>,
+    {
+        // Locate the operation
+        let command_file = self.index.locate_command_file(args)?;
+        let cmd_metadata = self.read_command(&command_file)?;
+        let cmd_cond = cmd_metadata.match_condition(&matches);
+        let operation = cmd_metadata
+                .select_operation_by_cond(cmd_cond.as_ref())
+                .ok_or(anyhow!(
+                    "failed to select the operation out from multiple operations available for this command based on the input"
+                ))?;
+
+        let mut body = None;
+        if operation.contains_request_body() {
+            let mut hcl_body = None;
+            if let Some(p) = matches.get_one::<PathBuf>("file") {
+                // Read the HCL from file
+                hcl_body = Some(get_file(&p)?);
+            } else if matches.get_flag("edit") {
+                // Read the HCL from editor
+                let header = "# ...".to_string();
+                let content = edit(
+                    &header,
+                    self.root_path.to_string_lossy().as_ref(),
+                    &command_file,
+                    cmd_cond.as_ref(),
+                )?;
+                let content = content.trim();
+
+                // If the content is "empty", pause the process and exit.
+                // This behavior is similar to "git commit".
+                if content == header || content.is_empty() {
+                    bail!("Aborting due to empty body");
+                }
+
+                hcl_body = Some(content.to_string());
+            }
+
+            body = if let Some(hcl_body) = hcl_body {
+                let body = hcl::parse(&hcl_body).context("parsing the file as HCL")?;
+                let v: serde_json::Value = hcl::from_body(body)?;
+                Some(v)
+            } else {
+                None
+            };
+
+            // Print CLI and quit
+            if let Some(shell) = matches.get_one::<String>("print-cli") {
+                let shell = Shell::from_str(shell.as_str())?;
+                let expander = CLIExpander::new(&shell, &cmd_metadata.arg_groups, args, body);
+                let args = expander.expand()?;
+                let mut cli = vec![];
+                cli.extend(subcommands.iter().cloned());
+                cli.extend(args);
+                return Ok(cli.join(" "));
+            }
+        }
+
+        // Invoke the operation
+        let invoker = OperationInvocation::new(operation, &matches, &body);
+        let cred = cred_func()?;
+        let client = Client::new(
+            "https://management.azure.com",
+            vec!["https://management.azure.com/.default"],
+            cred,
+            None,
+        )?;
+        invoker.invoke(&client).await
     }
 }
 
 #[cfg(any(feature = "embed-api", target_arch = "wasm32"))]
 mod embedded {
     use super::metadata_command::Command;
-    use anyhow::{Result, anyhow};
+    use anyhow::{anyhow, Result};
     use std::path::PathBuf;
 
     use rust_embed::RustEmbed;
@@ -41,6 +127,7 @@ mod embedded {
             let index = serde_json::from_slice(&bytes)?;
 
             Ok(Self {
+                root_path: PathBuf::new(),
                 index,
                 commands_path: PathBuf::new(),
             })
@@ -70,6 +157,7 @@ mod fs {
             let bytes = read(index_path).context(format!("reading the index file"))?;
             let index = serde_json::from_slice(&bytes)?;
             Ok(Self {
+                root_path: path.clone(),
                 index,
                 commands_path,
             })
@@ -81,4 +169,41 @@ mod fs {
             Ok(serde_json::from_slice(&bytes)?)
         }
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn get_file(_: &PathBuf) -> Result<String> {
+    Err(anyhow!(r#""--file" is not supported on wasm32"#))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn get_file(p: &PathBuf) -> Result<String> {
+    std::fs::read_to_string(p).context(format!("reading file from {p:?}"))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn edit(_: &String, _: &str, _: &str, _: Option<&String>) -> Result<String> {
+    Err(anyhow!(r#""--edit" is not supported on wasm32"#))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn edit(
+    content: &String,
+    metadata_path: &str,
+    cmd_file: &str,
+    cmd_cond: Option<&String>,
+) -> Result<String> {
+    use crate::lsp;
+
+    let mut envs = std::collections::HashMap::from([
+        (lsp::LSP_METADATA_PATH, metadata_path),
+        (lsp::LSP_CMD_FILE, cmd_file),
+    ]);
+    if let Some(cmd_cond) = cmd_cond {
+        envs.insert(lsp::LSP_CMD_CONDITION, cmd_cond);
+    }
+    Ok(
+        edit::edit_with_builder_with_env(content, tempfile::Builder::new().suffix(".az"), envs)?
+            .to_string(),
+    )
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -110,7 +110,7 @@ impl ApiManager {
                 }
 
                 // Invoke the operation
-                let invoker = OperationInvocation::new(operation, &matches, &body);
+                let invoker = OperationInvocation::new(operation, &matches, &Some(id), &body);
                 let client = Client::new(
                     "https://management.azure.com",
                     vec!["https://management.azure.com/.default"],
@@ -200,7 +200,12 @@ impl ApiManager {
         }
 
         // Invoke the operation
-        let invoker = OperationInvocation::new(operation, &matches, &body);
+        let invoker = OperationInvocation::new(
+            operation,
+            &matches,
+            &matches.get_one::<String>(cmd::ID_OPTION).cloned(),
+            &body,
+        );
         let client = Client::new(
             "https://management.azure.com",
             vec!["https://management.azure.com/.default"],

--- a/src/api.rs
+++ b/src/api.rs
@@ -52,7 +52,7 @@ impl ApiManager {
         let cmd_metadata = self.read_command(&command_file)?;
 
         if matches.get_flag(STDIN_OPTION) {
-            // Read the id and body from stdin, where each line shall be a JSON object containing
+            // Read the id and (optionally, only for PUT) body from stdin, where each line shall be a JSON object containing
             // the '.id' and other body attributes.
             let handle = io::stdin().lock();
             let mut results = vec![];
@@ -77,7 +77,7 @@ impl ApiManager {
                 ))?;
 
                 let mut body = None;
-                if operation.contains_request_body() {
+                if operation.is_put() {
                     obj.remove("id").unwrap();
                     let mut obj = serde_json::Value::Object(obj);
                     if let Some(schema) = operation

--- a/src/api.rs
+++ b/src/api.rs
@@ -44,9 +44,6 @@ impl ApiManager {
     {
         let cred = cred_func()?;
 
-        // Print CLI and quit
-        let print_cli = matches.get_one::<String>("print-cli").map(|v| v);
-
         // Locate the command metadata
         let command_file = self.index.locate_command_file(args)?;
         let cmd_metadata = self.read_command(&command_file)?;
@@ -93,7 +90,8 @@ impl ApiManager {
                     body = Some(obj);
                 }
 
-                if let Some(shell) = print_cli {
+                // Print CLI and quit
+                if let Some(shell) = matches.get_one::<String>("print-cli").map(|v| v) {
                     let shell = Shell::from_str(shell.as_str())?;
                     let expander = CLIExpander::new(
                         &shell,
@@ -188,17 +186,17 @@ impl ApiManager {
             } else {
                 None
             };
+        }
 
-            // Print CLI and quit
-            if let Some(shell) = print_cli {
-                let shell = Shell::from_str(shell.as_str())?;
-                let expander = CLIExpander::new(&shell, &cmd_metadata.arg_groups, args, body, None);
-                let args = expander.expand()?;
-                let mut cli = vec![];
-                cli.extend(subcommands.iter().cloned());
-                cli.extend(args);
-                return Ok(cli.join(" "));
-            }
+        // Print CLI and quit
+        if let Some(shell) = matches.get_one::<String>("print-cli").map(|v| v) {
+            let shell = Shell::from_str(shell.as_str())?;
+            let expander = CLIExpander::new(&shell, &cmd_metadata.arg_groups, args, body, None);
+            let args = expander.expand()?;
+            let mut cli = vec![];
+            cli.extend(subcommands.iter().cloned());
+            cli.extend(args);
+            return Ok(cli.join(" "));
         }
 
         // Invoke the operation

--- a/src/api.rs
+++ b/src/api.rs
@@ -83,7 +83,9 @@ impl ApiManager {
                     if let Some(schema) = operation
                         .http
                         .as_ref()
-                        .and_then(|http| http.request.body.as_ref())
+                        // The first response is the successful response
+                        .and_then(|http| http.responses.first())
+                        .and_then(|resp| resp.body.as_ref())
                         .and_then(|b| b.json.schema.as_ref())
                     {
                         schema.shake_body(&mut obj)?;

--- a/src/api/cli_expander.rs
+++ b/src/api/cli_expander.rs
@@ -1,6 +1,9 @@
 use std::str::FromStr;
 
-use crate::arg::{self, CliInput};
+use crate::{
+    arg::{self, CliInput},
+    cmd::ID_OPTION,
+};
 
 use super::metadata_command::ArgGroup;
 use anyhow::{anyhow, bail, Context, Result};
@@ -11,6 +14,7 @@ pub struct CLIExpander {
     arg_groups: Vec<ArgGroup>,
     arg_input: CliInput,
     body: Option<serde_json::Value>,
+    id: Option<String>,
 }
 
 impl CLIExpander {
@@ -19,12 +23,14 @@ impl CLIExpander {
         arg_groups: &Vec<ArgGroup>,
         cli_input: &CliInput,
         body: Option<serde_json::Value>,
+        id: Option<String>,
     ) -> Self {
         Self {
             shell: shell.clone(),
             arg_groups: arg_groups.clone(),
             arg_input: cli_input.clone(),
             body,
+            id,
         }
     }
 
@@ -35,6 +41,9 @@ impl CLIExpander {
                 continue;
             }
             cli_inputs.push(arg::Arg::Optional(k.to_string(), v.map(String::from)));
+        }
+        if let Some(ref id) = self.id {
+            cli_inputs.push(arg::Arg::Optional(ID_OPTION.to_string(), Some(id.clone())));
         }
 
         if let Some(ref body) = self.body {

--- a/src/api/invoke.rs
+++ b/src/api/invoke.rs
@@ -45,7 +45,6 @@ impl OperationInvocation {
         if let Some(id) = self.id.as_ref() {
             let id = cmd::ResourceId::from(id);
             id.validate_pattern(&http.path, &http.request.method)?;
-
             path = id.id();
             if http.request.method == Method::Post {
                 if let Some(last_seg) = http.path.split("/").last() {

--- a/src/api/invoke.rs
+++ b/src/api/invoke.rs
@@ -1,7 +1,7 @@
 use crate::{api::metadata_command::Method, cmd};
 
 use super::metadata_command::{Operation, Schema};
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::ArgMatches;
 use core::unreachable;
 use std::collections::HashMap;
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 pub struct OperationInvocation {
     operation: Operation,
     matches: ArgMatches,
+    id: Option<String>,
     body: Option<serde_json::Value>,
 }
 
@@ -16,11 +17,13 @@ impl OperationInvocation {
     pub fn new(
         operation: &Operation,
         matches: &ArgMatches,
+        id: &Option<String>,
         body: &Option<serde_json::Value>,
     ) -> Self {
         Self {
             operation: operation.clone(),
             matches: matches.clone(),
+            id: id.clone(),
             body: body.clone(),
         }
     }
@@ -38,8 +41,8 @@ impl OperationInvocation {
 
         let http = self.operation.http.as_ref().unwrap();
         let mut path;
-        // In case the "--id" is specified, we validate and use it.
-        if let Some(id) = self.matches.get_one::<String>(cmd::ID_OPTION) {
+        // In case the "id" is specified, we validate and use it.
+        if let Some(id) = self.id.as_ref() {
             let id = cmd::ResourceId::from(id);
             id.validate_pattern(&http.path, &http.request.method)?;
 

--- a/src/api/invoke.rs
+++ b/src/api/invoke.rs
@@ -40,11 +40,7 @@ impl OperationInvocation {
         let mut path;
         // In case the "--id" is specified, we validate and use it.
         if let Some(id) = self.matches.get_one::<String>(cmd::ID_OPTION) {
-            let id = if id == "-" {
-                cmd::ResourceId::from_stdin()?
-            } else {
-                cmd::ResourceId::from(id)
-            };
+            let id = cmd::ResourceId::from(id);
             id.validate_pattern(&http.path, &http.request.method)?;
 
             path = id.id();

--- a/src/api/metadata_command.rs
+++ b/src/api/metadata_command.rs
@@ -366,11 +366,7 @@ impl Command {
             return None;
         }
         if let Some(id) = matches.get_one::<String>(cmd::ID_OPTION) {
-            let id = if id == "-" {
-                cmd::ResourceId::from_stdin().ok()?
-            } else {
-                cmd::ResourceId::from(id)
-            };
+            let id = cmd::ResourceId::from(id);
             self.operations
                 .iter()
                 .find(|op| {

--- a/src/api/metadata_command.rs
+++ b/src/api/metadata_command.rs
@@ -399,6 +399,13 @@ impl Operation {
         }
         return false;
     }
+
+    pub fn is_put(&self) -> bool {
+        if let Some(method) = self.http.as_ref().map(|http| http.request.method) {
+            return method == Method::Put;
+        }
+        return false;
+    }
 }
 
 #[derive(Debug)]

--- a/src/api/metadata_command.rs
+++ b/src/api/metadata_command.rs
@@ -1,4 +1,6 @@
-use clap::ArgMatches;
+use std::collections::HashMap;
+
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use tower_lsp::lsp_types::CompletionItemKind;
 
@@ -266,6 +268,59 @@ pub struct AdditionalPropItemSchema {
 }
 
 impl Schema {
+    // shake_body removes all the readOnly attributes from the body.
+    pub fn shake_body(&self, body: &mut serde_json::Value) -> Result<()> {
+        self.shake_value(body)
+    }
+
+    fn shake_value(&self, body: &mut serde_json::Value) -> Result<()> {
+        match body {
+            serde_json::Value::Null
+            | serde_json::Value::Bool(_)
+            | serde_json::Value::Number(_)
+            | serde_json::Value::String(_) => {
+                return Ok(());
+            }
+            serde_json::Value::Array(values) => {
+                if let Some(item) = &self.item {
+                    if item.read_only.unwrap_or(false) {
+                        *values = vec![];
+                    }
+                    for value in values {
+                        self.shake_value(value)?;
+                    }
+                }
+                return Ok(());
+            }
+            serde_json::Value::Object(map) => {
+                if let Some(props) = &self.props {
+                    let mut keys_to_remove = vec![];
+                    for (k, v) in map.iter_mut() {
+                        if let Some(schema) = props.iter().find(|schema| {
+                            schema.name.as_ref().unwrap_or(&"".to_string()) == k.as_str()
+                        }) {
+                            // Schema found for the current kv, either continue to shake it or remove
+                            // it if read only.
+                            if schema.read_only.unwrap_or(false) {
+                                keys_to_remove.push(k.clone());
+                            } else {
+                                schema.shake_value(v)?;
+                            }
+                        } else {
+                            // Schema not found, which is likely user explicitly specified or some
+                            // new fields not defined in this version of schema.
+                            // Just keep it by doing nothing.
+                        }
+                    }
+                    keys_to_remove.iter().for_each(|k| {
+                        map.remove(k);
+                    });
+                }
+                return Ok(());
+            }
+        }
+    }
+
     pub fn to_hover_content(&self) -> String {
         let mut content = format!(
             "{} *{}*, {}",
@@ -346,6 +401,24 @@ impl Operation {
     }
 }
 
+#[derive(Debug)]
+pub enum ConditionOpt {
+    ID(String),
+    Names(HashMap<String, Option<String>>),
+}
+
+impl ConditionOpt {
+    pub fn new(id_arg: Option<String>, name_args: Option<HashMap<String, Option<String>>>) -> Self {
+        if let Some(id_arg) = id_arg {
+            return Self::ID(id_arg);
+        }
+        if let Some(names) = name_args {
+            return Self::Names(names);
+        }
+        unreachable!("neither id_arg nor name_args are specified");
+    }
+}
+
 impl Command {
     pub fn select_operation_by_cond(&self, cond: Option<&String>) -> Option<&Operation> {
         if let Some(cond) = cond {
@@ -361,51 +434,57 @@ impl Command {
         }
     }
 
-    pub fn match_condition(&self, matches: &ArgMatches) -> Option<String> {
+    pub fn build_condition(&self, opt: ConditionOpt) -> Option<String> {
         if self.conditions.is_none() {
             return None;
         }
-        if let Some(id) = matches.get_one::<String>(cmd::ID_OPTION) {
-            let id = cmd::ResourceId::from(id);
-            self.operations
-                .iter()
-                .find(|op| {
-                    op.http
-                        .as_ref()
-                        .map(|http| {
-                            id.validate_pattern(&http.path, &http.request.method)
-                                .is_ok()
-                        })
-                        .unwrap_or(false)
-                })
-                .and_then(|op| op.when.as_ref())
-                .and_then(|when| when.last())
-                .cloned()
-        } else {
-            self.conditions
+        match opt {
+            ConditionOpt::ID(id) => {
+                let id = cmd::ResourceId::from(id);
+                self.operations
+                    .iter()
+                    .find(|op| {
+                        op.http
+                            .as_ref()
+                            .map(|http| {
+                                id.validate_pattern(&http.path, &http.request.method)
+                                    .is_ok()
+                            })
+                            .unwrap_or(false)
+                    })
+                    .and_then(|op| op.when.as_ref())
+                    .and_then(|when| when.last())
+                    .cloned()
+            }
+            ConditionOpt::Names(names) => self
+                .conditions
                 .as_ref()
                 .unwrap()
                 .iter()
-                .find(|&c| self.match_operator(&c.operator, matches))
-                .map(|c| c.var.clone())
+                .find(|&c| self.match_operator(&c.operator, &names))
+                .map(|c| c.var.clone()),
         }
     }
 
-    fn match_operator(&self, operator: &ConditionOperator, matches: &ArgMatches) -> bool {
+    fn match_operator(
+        &self,
+        operator: &ConditionOperator,
+        names: &HashMap<String, Option<String>>,
+    ) -> bool {
         match operator {
             ConditionOperator::Operators { operators, type_ } => match type_ {
                 ConditionOperatorType::Not | ConditionOperatorType::HasValue => unreachable!(
                     r#"operators' condition type can only be "and" or "or", got=%{type_:?}"#
                 ),
                 ConditionOperatorType::And => {
-                    operators.iter().all(|o| self.match_operator(o, matches))
+                    operators.iter().all(|o| self.match_operator(o, names))
                 }
                 ConditionOperatorType::Or => {
-                    operators.iter().any(|o| self.match_operator(o, matches))
+                    operators.iter().any(|o| self.match_operator(o, names))
                 }
             },
             ConditionOperator::Operator { operator, type_ } => match type_ {
-                ConditionOperatorType::Not => !self.match_operator(operator, matches),
+                ConditionOperatorType::Not => !self.match_operator(operator, names),
                 ConditionOperatorType::HasValue
                 | ConditionOperatorType::And
                 | ConditionOperatorType::Or => {
@@ -413,7 +492,7 @@ impl Command {
                 }
             },
             ConditionOperator::Arg { arg, type_ } => match type_ {
-                ConditionOperatorType::HasValue => matches.get_raw(arg).is_some(),
+                ConditionOperatorType::HasValue => names.get(arg).and_then(|v| v.clone()).is_some(),
                 ConditionOperatorType::Not
                 | ConditionOperatorType::And
                 | ConditionOperatorType::Or => unreachable!(

--- a/src/arg.rs
+++ b/src/arg.rs
@@ -1,9 +1,32 @@
+use std::fmt::Display;
+
 use anyhow::Result;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Arg {
     Optional(String, Option<String>), // Can be: --enable, --enable=true, --foo bar
     Positional(String),
+}
+
+impl Display for Arg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Arg::Optional(k, v) => {
+                f.write_str("-")?;
+                if k.len() != 1 {
+                    f.write_str("-")?;
+                }
+                f.write_str(k)?;
+                if let Some(v) = v {
+                    write!(f, "={}", v)?;
+                }
+            }
+            Arg::Positional(v) => {
+                f.write_str(v)?;
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -91,6 +114,19 @@ impl CliInput {
             .filter_map(|arg| {
                 if let Arg::Positional(arg) = arg {
                     Some(arg.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    pub fn opt_args(&self) -> Vec<(&str, Option<&str>)> {
+        self.args
+            .iter()
+            .filter_map(|arg| {
+                if let Arg::Optional(k, v) = arg {
+                    Some((k.as_str(), v.as_ref().map(|v| v.as_str())))
                 } else {
                     None
                 }

--- a/src/bin/azure.rs
+++ b/src/bin/azure.rs
@@ -14,15 +14,19 @@ async fn main() -> Result<()> {
         Ok(cred)
     };
 
-    let res = run(
+    let result_func = |res: String| {
+        println!("{res}");
+    };
+
+    run(
         PathBuf::from_str("./metadata/metadata")?,
         env::args_os()
             .into_iter()
             .map(|s| s.into_string().unwrap())
             .collect(),
         cred_func,
+        result_func,
     )
     .await?;
-    println!("{res}");
     Ok(())
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -4,7 +4,7 @@ use crate::api::cli_expander::Shell;
 use crate::api::metadata_command::Method;
 use crate::api::{metadata_command, metadata_index, ApiManager};
 use crate::arg::CliInput;
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use clap::builder::PossibleValuesParser;
 use clap::{command, Arg, Command};
 
@@ -57,35 +57,6 @@ impl ResourceId {
             }
         }
         return Ok(());
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl ResourceId {
-    pub fn from_stdin() -> Result<Self> {
-        use std::io::{self, Read};
-
-        use serde_json::Value;
-        let mut buf = String::new();
-        io::stdin().read_to_string(&mut buf)?;
-        let obj: Value = serde_json::from_str(&buf)?;
-        let obj = obj
-            .as_object()
-            .ok_or(anyhow!("expect a JSON object as input"))?;
-        let id = obj
-            .get("id")
-            .ok_or(anyhow!(r#"there is no "id" key found in the JSON object"#))?;
-        let id = id
-            .as_str()
-            .ok_or(anyhow!(r#"expect the "id" key to be a string"#))?;
-        Ok(Self::from(id))
-    }
-}
-
-#[cfg(target_arch = "wasm32")]
-impl ResourceId {
-    pub fn from_stdin() -> Result<Self> {
-        bail!("id can't be read from stdin in WASM32")
     }
 }
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -2,11 +2,11 @@ use std::collections::HashMap;
 
 use crate::api::cli_expander::Shell;
 use crate::api::metadata_command::Method;
-use crate::api::{ApiManager, metadata_command, metadata_index};
+use crate::api::{metadata_command, metadata_index, ApiManager};
 use crate::arg::CliInput;
-use anyhow::{Result, anyhow, bail};
+use anyhow::{anyhow, bail, Result};
 use clap::builder::PossibleValuesParser;
-use clap::{Arg, Command, command};
+use clap::{command, Arg, Command};
 
 pub const ID_OPTION: &str = "id";
 pub const STDIN_OPTION: &str = "stdin";
@@ -314,7 +314,7 @@ fn build_args(versions: &Vec<String>, command: &metadata_command::Command) -> Ve
                 .long(STDIN_OPTION)
                 .action(clap::ArgAction::SetTrue)
                 .conflicts_with(ID_OPTION)
-                .help(format!(r#"Reading the resource id and request payload from stdin. The content read from the stdin can be one or multiple compact JSON objects. This conflicts with {conflicts:?}"#))
+                .help(format!(r#"Reading the resource id and request payload (only for "create" commands) from stdin as one or multiple compact JSON objects. This conflicts with {conflicts:?}"#))
         );
     }
 
@@ -409,6 +409,7 @@ fn build_arg(arg: &metadata_command::Arg) -> Arg {
 
     let conflicts = [ID_OPTION, STDIN_OPTION];
     if arg.id_part.is_some() {
+        // Update help message
         let mut msg = out
             .get_help()
             .and_then(|help| Some(help.to_string()))
@@ -418,10 +419,8 @@ fn build_arg(arg: &metadata_command::Arg) -> Arg {
         }
         msg += format!(r#"This conflicts with {conflicts:?}"#,).as_str();
         out = out.help(msg);
-    }
 
-    // Only ID related options will be required.
-    if arg.id_part.is_some() {
+        // Update conflicts/requireness
         out = out.conflicts_with_all(conflicts);
         if let Some(required) = arg.required {
             if required {

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -2,11 +2,11 @@ use std::collections::HashMap;
 
 use crate::api::cli_expander::Shell;
 use crate::api::metadata_command::Method;
-use crate::api::{ApiManager, metadata_command, metadata_index};
+use crate::api::{metadata_command, metadata_index, ApiManager};
 use crate::arg::CliInput;
-use anyhow::{Result, anyhow, bail};
+use anyhow::{anyhow, bail, Result};
 use clap::builder::PossibleValuesParser;
-use clap::{Arg, Command, command};
+use clap::{command, Arg, Command};
 
 pub const ID_OPTION: &str = "id";
 pub const STDIN_OPTION: &str = "stdin";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,9 @@
-use anyhow::{anyhow, bail, Context, Result};
-use api::{
-    cli_expander::{CLIExpander, Shell},
-    invoke::OperationInvocation,
-    ApiManager,
-};
+use anyhow::Result;
+use api::ApiManager;
 use arg::CliInput;
 use azure_core::credentials::TokenCredential;
 use clap::{ArgMatches, Command};
-use client::Client;
-use std::{path::PathBuf, str::FromStr, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
 pub mod api;
 pub mod arg;
@@ -43,82 +38,23 @@ where
             } else {
                 vec![]
             };
-            let input = CliInput::new(args)?;
+            let args = CliInput::new(args)?;
             let api_manager = ApiManager::new(&metadata_path)?;
-            let cmd = cmd::cmd_api(&api_manager, &input);
+            let cmd = cmd::cmd_api(&api_manager, &args);
             let mut matches = get_matches(cmd, raw_input.clone())?;
 
             // Reaches here indicates an API command/operation is specified.
 
             // Match the subcommand to the end, which returns the matches for the last subcommand.
-            while let Some((_, m)) = matches.subcommand() {
+            let mut subcommands = vec![raw_input[0].to_string()];
+            while let Some((cmd, m)) = matches.subcommand() {
+                subcommands.push(cmd.to_string());
                 matches = m.clone();
             }
 
-            // Locate the operation
-            let command_file = api_manager.locate_command_file(&input)?;
-            let cmd_metadata = api_manager.read_command(&command_file)?;
-            let cmd_cond = cmd_metadata.match_condition(&matches);
-            let operation = cmd_metadata
-                .select_operation_by_cond(cmd_cond.as_ref())
-                .ok_or(anyhow!(
-                    "failed to select the operation out from multiple operations available for this command based on the input"
-                ))?;
-
-            let mut body = None;
-            if operation.contains_request_body() {
-                let mut hcl_body = None;
-                if let Some(p) = matches.get_one::<PathBuf>("file") {
-                    // Read the HCL from file
-                    hcl_body = Some(get_file(&p)?);
-                } else if matches.get_flag("edit") {
-                    // Read the HCL from editor
-                    let header = "# ...".to_string();
-                    let content = edit(
-                        &header,
-                        metadata_path.to_string_lossy().as_ref(),
-                        &command_file,
-                        cmd_cond.as_ref(),
-                    )?;
-                    let content = content.trim();
-
-                    // If the content is "empty", pause the process and exit.
-                    // This behavior is similar to "git commit".
-                    if content == header || content.is_empty() {
-                        bail!("Aborting due to empty body");
-                    }
-
-                    hcl_body = Some(content.to_string());
-                }
-
-                body = if let Some(hcl_body) = hcl_body {
-                    let body = hcl::parse(&hcl_body).context("parsing the file as HCL")?;
-                    let v: serde_json::Value = hcl::from_body(body)?;
-                    Some(v)
-                } else {
-                    None
-                };
-
-                // Print CLI and quit
-                if let Some(shell) = matches.get_one::<String>("print-cli") {
-                    let shell = Shell::from_str(shell.as_str())?;
-                    let expander =
-                        CLIExpander::new(&shell, &cmd_metadata.arg_groups, &raw_input, body);
-                    return expander.expand();
-                }
-            }
-
-            // Invoke the operation
-            let invoker = OperationInvocation::new(operation, &matches, &body);
-            let cred = cred_func()?;
-            let client = Client::new(
-                "https://management.azure.com",
-                vec!["https://management.azure.com/.default"],
-                cred,
-                None,
-            )?;
-            let res = invoker.invoke(&client).await?;
-            return Ok(res);
+            api_manager
+                .run(&subcommands, &args, &matches, cred_func)
+                .await
         }
         _ => unreachable!("Exhausted list of subcommands and subcommand_required prevents `None`"),
     }
@@ -136,39 +72,4 @@ fn get_matches(cmd: Command, input: Vec<String>) -> Result<ArgMatches> {
 #[cfg(not(target_arch = "wasm32"))]
 fn get_matches(cmd: Command, input: Vec<String>) -> Result<ArgMatches> {
     Ok(cmd.get_matches_from(input))
-}
-
-#[cfg(target_arch = "wasm32")]
-fn get_file(_: &PathBuf) -> Result<String> {
-    Err(anyhow!(r#""--file" is not supported on wasm32"#))
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn get_file(p: &PathBuf) -> Result<String> {
-    std::fs::read_to_string(p).context(format!("reading file from {p:?}"))
-}
-
-#[cfg(target_arch = "wasm32")]
-fn edit(_: &String, _: &str, _: &str, _: Option<&String>) -> Result<String> {
-    Err(anyhow!(r#""--edit" is not supported on wasm32"#))
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn edit(
-    content: &String,
-    metadata_path: &str,
-    cmd_file: &str,
-    cmd_cond: Option<&String>,
-) -> Result<String> {
-    let mut envs = std::collections::HashMap::from([
-        (lsp::LSP_METADATA_PATH, metadata_path),
-        (lsp::LSP_CMD_FILE, cmd_file),
-    ]);
-    if let Some(cmd_cond) = cmd_cond {
-        envs.insert(lsp::LSP_CMD_CONDITION, cmd_cond);
-    }
-    Ok(
-        edit::edit_with_builder_with_env(content, tempfile::Builder::new().suffix(".az"), envs)?
-            .to_string(),
-    )
 }

--- a/src/wasm_exports.rs
+++ b/src/wasm_exports.rs
@@ -16,7 +16,15 @@ pub async fn run_cli(args: Vec<String>, token: &str) -> Result<String, JsValue> 
         let cred = AccessTokenCredential::new(token.to_string())?;
         Ok(cred)
     };
-    run(PathBuf::new(), args, cred_func).await.map_err(jsfy)
+
+    let mut resp = Default::default();
+    let resp_func = |res: String| {
+        resp = res;
+    };
+    run(PathBuf::new(), args, cred_func, resp_func)
+        .await
+        .map_err(jsfy)?;
+    Ok(resp)
 }
 
 fn jsfy<E>(e: E) -> JsValue


### PR DESCRIPTION
This PR adds a new option `--stdin` to the `api` subcommand.

This option will read the resource id from the standard input, assuming each line is a JSON object that has a `id` field. While, the `id` is validated by the specified command to avoid an invalid id is specified for a certain command.

Especially for `PUT` method (i.e. `create` leaf command), it also honors and uses whole the JSON object as the `PUT` request payload, with all read only attributes defined in the response schema removed. This allows the user to add attributes which is not recorded in the metadata, whilst valid (e.g. targeting to a new api version).

The process is serialized, which means the command is applied to each input JSON object one by one. Once any failed, the process stops. The output of the command runs is streamlined, which can be piped on. If you want parallel run and avoid short-circuit failure, suggest to use GNU `parallel` (e.g. `parallel --pipe -N 1` with `--stdin`, or `parallel -N 1` with `--id`).

---

## Example

1. Update all the virtual networks under a subscription that contains `acctest` in the `id`, by setting their `tags`.

    ```shell
    $ az-rs api network virtual-network list --subscription $ARM_SUBSCRIPTION_ID| jq -c '.value.[] | select(.id | contains("acctest")) | .tags={env:"test"}' | az-rs api network virtual-network create --stdin
    ```
---

This PR also moves the `api` subcommand main logic from *lib.rs* to a dedicated `ApiManager.run()` method in *api.rs*.

